### PR TITLE
Update go-ipfs.nuspec

### DIFF
--- a/go-ipfs/go-ipfs.nuspec
+++ b/go-ipfs/go-ipfs.nuspec
@@ -8,7 +8,7 @@
     <authors>ipfs</authors>
     <owners>ipfs</owners>
     <summary>IPFS implementation in Go https://ipfs.tech</summary>
-    <description>IPFS implementation in Go
+    <description>IPFS implementation in Go https://ipfs.tech
     </description>
     <projectUrl>https://github.com/ipfs/kubo</projectUrl>
     <packageSourceUrl>https://github.com/ipfs/choco-go-ipfs</packageSourceUrl>


### PR DESCRIPTION
https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0032 became a requirement. We need a description longer than 30 characters.