### PR TITLE
Do not check choco version on publish if requested

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
         run: choco install au
       - name: Build the latest release 🏗️
         env:
-          NoCheckChocoVersion: ${{ github.event.inputs.no-check-choco-version }}
+          NoCheckChocoVersion: ${{ github.event.inputs.no-check-choco-version || 'False' }}
         run: |
           ./update.ps1
           choco pack

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,6 @@ on:
       no-check-choco-version:
         required: false
         description: Disable version check in the Chocolatey community feed
-        default: "false"
   schedule:
     - cron: '0 0 * * *'
 
@@ -51,7 +50,7 @@ jobs:
         run: choco install au
       - name: Build the latest release 🏗️
         env:
-          NoCheckChocoVersion: ${{ github.event.inputs.no-check-choco-version || 'false' }}
+          NoCheckChocoVersion: ${{ github.event.inputs.no-check-choco-version }}
         run: |
           ./update.ps1
           choco pack

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,11 @@
 name: Release to Chocolatey
 on:
   workflow_dispatch:
+    inputs:
+      no-check-choco-version:
+        required: false
+        description: Disable version check in the Chocolatey community feed
+        default: "false"
   schedule:
     - cron: '0 0 * * *'
 
@@ -45,6 +50,8 @@ jobs:
       - name: Install Dependencies
         run: choco install au
       - name: Build the latest release 🏗️
+        env:
+          NoCheckChocoVersion: ${{ github.event.inputs.no-check-choco-version || 'false' }}
         run: |
           ./update.ps1
           choco pack

--- a/go-ipfs/update.ps1
+++ b/go-ipfs/update.ps1
@@ -30,4 +30,9 @@ function global:au_GetLatest {
 	return @{ Version = $version; URL32 = $url32; URL64 = $url64 }
 }
 
-Update-Package -ChecksumFor none
+if ([bool]::Parse($Env:NoCheckChocoVersion)) {
+	Update-Package -ChecksumFor none -NoCheckChocoVersion
+}
+else {
+	Update-Package -ChecksumFor none
+}


### PR DESCRIPTION
Merging this because I used this to release new v0.16.0 version - https://github.com/ipfs/choco-go-ipfs/actions/runs/3264415082.

This will become obsolete altogether with https://github.com/ipfs/kubo/issues/9341