### PR TITLE
chore: disable scheduled chocolatey releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,6 @@ on:
       no-check-choco-version:
         required: false
         description: Disable version check in the Chocolatey community feed
-  schedule:
-    - cron: '0 0 * * *'
 
 concurrency:
   group: single-run


### PR DESCRIPTION
Disabling automatic chocolatey releases as per https://github.com/ipfs/kubo/issues/9341